### PR TITLE
Add the possibility to manually insert peaks that were not found *automagically*

### DIFF
--- a/peakdet/editor.py
+++ b/peakdet/editor.py
@@ -107,19 +107,20 @@ class _PhysioEditor():
         self.plot_signals()
 
     def on_include(self, xmin, xmax):
-        """ Include specified peaks by slecting the highest point in the selection """
+        """ Include ONE peak by slecting the highest point in the selection """
         tmin, tmax = np.searchsorted(self.time, (xmin, xmax))
-        pmin, pmax = np.searchsorted(self.data.peaks, (tmin, tmax))
-        good = np.arange(pmin, pmax, dtype=int)
+        pins = np.searchsorted(self.data.peaks, tmin)
+        temp_peak = np.argmax(self.data.data[tmin:tmax])
 
-        if len(good) == 0:
+        if temp_peak == 0:
             return
 
+        newpeak = tmin + temp_peak
         add, fcn = self.included, operations.add_peaks
 
         # store edits in local history
-        add.update(self.data.peaks[good].tolist())
-        self.data = fcn(self.data, self.data.peaks[good])
+        add.update(newpeak.tolist())
+        self.data = fcn(self.data, newpeak, pins)
         self.plot_signals()
 
     def undo(self):

--- a/peakdet/editor.py
+++ b/peakdet/editor.py
@@ -38,7 +38,7 @@ class _PhysioEditor():
         # three selectors for rejection (left mouse), addition (central mouse), and deletion (right mouse)
         reject = functools.partial(self.on_edit, reject=True)
         delete = functools.partial(self.on_edit, reject=False)
-        include = functools.partial(self.on_edit, insert=True)
+        include = functools.partial(self.on_edit, reject=False, insert=True)
         self.span1 = SpanSelector(self.ax, reject, 'horizontal',
                                   button=1, useblit=True,
                                   rectprops=dict(facecolor='red', alpha=0.3))
@@ -107,7 +107,7 @@ class _PhysioEditor():
             temp_peak = np.argmax(self.data.data[tmin:tmax])
             if temp_peak == 0:
                 return
-            newpeak = tmin + temp_peak
+            newpeak = [tmin + temp_peak]
         else:
             bad = np.arange(pmin, pmax, dtype=int)
             if len(bad) == 0:
@@ -120,7 +120,7 @@ class _PhysioEditor():
 
         # store edits in local history & call function
         if insert:
-            self.included.update(newpeak.tolist())
+            self.included.add(newpeak)
             self.data = operations.add_peaks(self.data, newpeak, pmin)
         else:
             rej.update(self.data.peaks[bad].tolist())

--- a/peakdet/editor.py
+++ b/peakdet/editor.py
@@ -106,6 +106,22 @@ class _PhysioEditor():
         self.data = fcn(self.data, self.data.peaks[bad])
         self.plot_signals()
 
+    def on_include(self, xmin, xmax):
+        """ Include specified peaks by slecting the highest point in the selection """
+        tmin, tmax = np.searchsorted(self.time, (xmin, xmax))
+        pmin, pmax = np.searchsorted(self.data.peaks, (tmin, tmax))
+        good = np.arange(pmin, pmax, dtype=int)
+
+        if len(good) == 0:
+            return
+
+        add, fcn = self.included, operations.add_peaks
+
+        # store edits in local history
+        add.update(self.data.peaks[good].tolist())
+        self.data = fcn(self.data, self.data.peaks[good])
+        self.plot_signals()
+
     def undo(self):
         """ Resets last span select peak removal """
         # check if last history entry was a manual reject / delete

--- a/peakdet/editor.py
+++ b/peakdet/editor.py
@@ -28,22 +28,26 @@ class _PhysioEditor():
 
         # we need to create these variables in case someone doesn't "quit"
         # the plot appropriately (i.e., clicks X instead of pressing ctrl+q)
-        self.deleted, self.rejected = set(), set()
+        self.deleted, self.rejected, self.included = set(), set(), set()
 
         # make main plot objects
         self.fig, self.ax = plt.subplots(nrows=1, ncols=1, tight_layout=True)
         self.fig.canvas.mpl_connect('scroll_event', self.on_wheel)
         self.fig.canvas.mpl_connect('key_press_event', self.on_key)
 
-        # two selectors for rejection (left mouse) and deletion (right mouse)
+        # three selectors for rejection (left mouse), addition (central mouse), and deletion (right mouse)
         reject = functools.partial(self.on_remove, reject=True)
         delete = functools.partial(self.on_remove, reject=False)
+        include = functools.partial(self.on_include)
         self.span1 = SpanSelector(self.ax, reject, 'horizontal',
                                   button=1, useblit=True,
                                   rectprops=dict(facecolor='red', alpha=0.3))
         self.span2 = SpanSelector(self.ax, delete, 'horizontal',
                                   button=3, useblit=True,
                                   rectprops=dict(facecolor='blue', alpha=0.3))
+        self.span3 = SpanSelector(self.ax, include, 'horizontal',
+                                  button=2, useblit=True,
+                                  rectprops=dict(facecolor='green', alpha=0.3))
 
         self.plot_signals(False)
 

--- a/peakdet/operations.py
+++ b/peakdet/operations.py
@@ -182,6 +182,28 @@ def reject_peaks(data, remove):
     return data
 
 
+@utils.make_operation()
+def add_peaks(data, scan):
+    """
+    Find peaks in `remove` to add them in `data`
+
+    Parameters
+    ----------
+    data : Physio_like
+    remove : array_like
+
+    Returns
+    -------
+    data : Physio_like
+    """
+
+    data = utils.check_physio(data, ensure_fs=False, copy=True)
+    data._metadata['reject'] = np.append(data._metadata['reject'], remove)
+    data._metadata['troughs'] = utils.check_troughs(data, data.peaks)
+
+    return data
+
+
 def edit_physio(data):
     """
     Opens interactive plot with `data` to permit manual editing of time series

--- a/peakdet/operations.py
+++ b/peakdet/operations.py
@@ -183,14 +183,14 @@ def reject_peaks(data, remove):
 
 
 @utils.make_operation()
-def add_peaks(data, scan):
+def add_peaks(data, newpeak, pins):
     """
-    Find peaks in `scan` to add them in `data`
+    Add `newpeak` to add them in `data`
 
     Parameters
     ----------
     data : Physio_like
-    remove : array_like
+    newpeak : int
 
     Returns
     -------
@@ -198,7 +198,7 @@ def add_peaks(data, scan):
     """
 
     data = utils.check_physio(data, ensure_fs=False, copy=True)
-    data._metadata['peaks'] = np.append(data._metadata['peaks'], scan)
+    data._metadata['peaks'] = np.insert(data._metadata['peaks'], pins, newpeak)
     data._metadata['troughs'] = utils.check_troughs(data, data.peaks)
 
     return data

--- a/peakdet/operations.py
+++ b/peakdet/operations.py
@@ -185,7 +185,7 @@ def reject_peaks(data, remove):
 @utils.make_operation()
 def add_peaks(data, scan):
     """
-    Find peaks in `remove` to add them in `data`
+    Find peaks in `scan` to add them in `data`
 
     Parameters
     ----------
@@ -198,7 +198,7 @@ def add_peaks(data, scan):
     """
 
     data = utils.check_physio(data, ensure_fs=False, copy=True)
-    data._metadata['reject'] = np.append(data._metadata['reject'], remove)
+    data._metadata['peaks'] = np.append(data._metadata['peaks'], scan)
     data._metadata['troughs'] = utils.check_troughs(data, data.peaks)
 
     return data


### PR DESCRIPTION
This PR adds the possibility to manually insert peaks that were not found *automagically*.

### Changes:
- Update `on_remove` to `on_edit`, since now we're also adding
- `on_edit` contains a quick script that finds the max of a selected area and returns it as a peak
- Add a new operation, `add_peaks`
- This new operation should be available in `edit_physio()` using the middle button of a mouse (in current mouses, pressing the scroll wheel). Later on the rejection and insertion might be swapped (depending on frequency of use).

### However
It doesn't work yet. At the moment, I'm stuck by the fact that for some reasons I don't understand, I can't add an integer to a set because it's not an iterable. Also, the trick of undoing this step and how to add it to the history are still a bit of an arcana to me.

@rmarkello if you have a bit of time, I'm going to ask your help with this...