### PR TITLE
rectprops update

### DIFF
--- a/peakdet/editor.py
+++ b/peakdet/editor.py
@@ -3,6 +3,7 @@
 
 import functools
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.widgets import SpanSelector
 from peakdet import operations, utils
@@ -52,15 +53,21 @@ class _PhysioEditor():
         delete = functools.partial(self.on_edit, method='delete')
         reject = functools.partial(self.on_edit, method='reject')
         insert = functools.partial(self.on_edit, method='insert')
+        # Check matplotlib version rectprops is deprecated with matplotlib 3.5.0 and then obsolete 
+        if matplotlib.__version__ >= '3.5.0':
+            property_name = 'props'
+        else:
+            property_name = 'rectprops'
+        
         self.span2 = SpanSelector(self.ax, delete, 'horizontal',
-                                  button=1, useblit=True,
-                                  rectprops=dict(facecolor='red', alpha=0.3))
+                        button=1, useblit=True,
+                        **{property_name: dict(facecolor='red', alpha=0.3)})
         self.span1 = SpanSelector(self.ax, reject, 'horizontal',
-                                  button=2, useblit=True,
-                                  rectprops=dict(facecolor='blue', alpha=0.3))
+                        button=2, useblit=True,
+                        **{property_name: dict(facecolor='blue', alpha=0.3)})
         self.span3 = SpanSelector(self.ax, insert, 'horizontal',
-                                  button=3, useblit=True,
-                                  rectprops=dict(facecolor='green', alpha=0.3))
+                        button=3, useblit=True,
+                        **{property_name: dict(facecolor='green', alpha=0.3)})
 
         self.plot_signals(False)
 


### PR DESCRIPTION
Re-forked and new pull request to implement changes for deprecated rectprops with props in matplotlib function call. This version checks for older  versions of matplotlib to continue with old behavior.
